### PR TITLE
[WIP] Mark `componentWillMount`s as unsafe

### DIFF
--- a/src/control.ts
+++ b/src/control.ts
@@ -82,7 +82,7 @@ class Control extends Component<Props, State> {
   get isTouched() { return this.state.touched; }
   get isUntouched() { return !this.isTouched; }
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     this.context.form.addControl(this.props.name, this);
   }
 

--- a/src/form.ts
+++ b/src/form.ts
@@ -53,7 +53,7 @@ class Form extends Component<Props, State> {
     this.update = this.update.bind(this);
   }
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     this.mounted = true;
   }
 


### PR DESCRIPTION
fixes #19.

- [ ] fix failing tests

tests are failing because unsafe aliases available only in React 16.3+ but tests are running with React 15.4. for using 16.3+ in tests [enzyme 2 also needs to be upgraded to 3 ](https://enzymejs.github.io/enzyme/docs/guides/migration-from-2-to-3.html)